### PR TITLE
fix: 请求错误毋需带上成功时的类型

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,10 +13,6 @@ export type ResponseError =
       extra?: Record<string, any>;
     }
   | {
-      statusCode: 200;
-      data: Record<string, any>;
-    }
-  | {
       statusCode: 400;
       message: string[];
       error: string;


### PR DESCRIPTION
# Change Log

## 团队规范

- 请求错误响应返回类型中，删掉不需要的联合类型