### PR TITLE
feat: 整理通用组件

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.0",
-    "tailwindcss": "^3.3.3",
     "typescript": "^4.9.5",
     "unocss": "^0.53.5",
     "vite": "^4.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,9 +58,6 @@ devDependencies:
   prettier:
     specifier: ^3.0.0
     version: 3.0.0
-  tailwindcss:
-    specifier: ^3.3.3
-    version: 3.3.3
   typescript:
     specifier: ^4.9.5
     version: 4.9.5
@@ -82,11 +79,6 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /@alloc/quick-lru@5.2.0:
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -1308,20 +1300,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
-
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
-
-  /arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
     dev: true
 
   /argparse@2.0.1:
@@ -1489,11 +1473,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /caniuse-lite@1.0.30001517:
     resolution: {integrity: sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==}
     dev: true
@@ -1600,11 +1579,6 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -1633,12 +1607,6 @@ packages:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.0.2
-    dev: true
-
-  /cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
     dev: true
 
   /csstype@3.1.2:
@@ -1704,19 +1672,11 @@ packages:
     resolution: {integrity: sha512-FJ9RDpf3GicEBvzI3jxc2XhHzbqD8p4ANw/1kPsFBfTvP1b7Gn/Lg1vO7R9J4IVgoMbyUmFrFGZafJ1hPZpvlg==}
     dev: true
 
-  /didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-    dev: true
-
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-    dev: true
-
-  /dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
   /doctrine@3.0.0:
@@ -2213,17 +2173,6 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob@7.1.6:
-    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
@@ -2435,12 +2384,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
-    dependencies:
-      has: 1.0.3
     dev: true
 
   /is-date-object@1.0.5:
@@ -2663,10 +2606,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
-
   /lint-staged@13.2.3:
     resolution: {integrity: sha512-zVVEXLuQIhr1Y7R7YAWx4TZLdvuzk7DnmrsTNL0fax6Z3jrpFcas+vKbzxhhvp6TA55m1SQuWkpzI1qbfDZbAg==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -2824,14 +2763,6 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-    dev: true
-
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2871,16 +2802,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
-    dev: true
-
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
     dev: true
 
   /object-inspect@1.12.3:
@@ -3009,10 +2930,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
-
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3039,77 +2956,6 @@ packages:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
-    dev: true
-
-  /pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /postcss-import@15.1.0(postcss@8.4.26):
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss: 8.4.26
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.2
-    dev: true
-
-  /postcss-js@4.0.1(postcss@8.4.26):
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.4.26
-    dev: true
-
-  /postcss-load-config@4.0.1(postcss@8.4.26):
-    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      postcss: 8.4.26
-      yaml: 2.3.1
-    dev: true
-
-  /postcss-nested@6.0.1(postcss@8.4.26):
-    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-    dependencies:
-      postcss: 8.4.26
-      postcss-selector-parser: 6.0.13
-    dev: true
-
-  /postcss-selector-parser@6.0.13:
-    resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-    dev: true
-
-  /postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
   /postcss@8.4.26:
@@ -3152,12 +2998,6 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-    dependencies:
-      pify: 2.3.0
-    dev: true
-
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3177,15 +3017,6 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
-
-  /resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
-    hasBin: true
-    dependencies:
-      is-core-module: 2.12.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
   /restore-cursor@3.1.0:
@@ -3452,20 +3283,6 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /sucrase@3.33.0:
-    resolution: {integrity: sha512-ARGC7vbufOHfpvyGcZZXFaXCMZ9A4fffOGC5ucOW7+WHDGlAe8LJdf3Jts1sWhDeiI1RSWrKy5Hodl+JWGdW2A==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      commander: 4.1.1
-      glob: 7.1.6
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.6
-      ts-interface-checker: 0.1.13
-    dev: true
-
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -3480,11 +3297,6 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3493,52 +3305,8 @@ packages:
       tslib: 2.6.0
     dev: true
 
-  /tailwindcss@3.3.3:
-    resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.5.3
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.0
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.19.1
-      lilconfig: 2.1.0
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.26
-      postcss-import: 15.1.0(postcss@8.4.26)
-      postcss-js: 4.0.1(postcss@8.4.26)
-      postcss-load-config: 4.0.1(postcss@8.4.26)
-      postcss-nested: 6.0.1(postcss@8.4.26)
-      postcss-selector-parser: 6.0.13
-      resolve: 1.22.2
-      sucrase: 3.33.0
-    transitivePeerDependencies:
-      - ts-node
-    dev: true
-
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-    dev: true
-
-  /thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      thenify: 3.3.1
-    dev: true
-
-  /thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-    dependencies:
-      any-promise: 1.3.0
     dev: true
 
   /through@2.3.8:
@@ -3574,10 +3342,6 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 4.9.5
-    dev: true
-
-  /ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
   /tslib@1.14.1:
@@ -3736,10 +3500,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-    dev: true
-
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
   /validate-html-nesting@1.2.2:

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -12,6 +12,9 @@ import {
 } from '@/api/auth';
 import { setJwt, setUser, User } from '@/store/user';
 import { ResponseError } from '@/api';
+import { match, required, length } from '@/utils/validators';
+import { Validator } from '@/types';
+import Button from '@/components/Button';
 
 export default function AuthButton() {
   const [modalVisible, setModalVisible] = createSignal(false);
@@ -69,6 +72,23 @@ export default function AuthButton() {
     setModalVisible(false);
   }
 
+  function accountValidator(): Validator[] {
+    return [
+      required(),
+      type() === 'register' &&
+        match(/^[a-zA-Z0-9._]*$/, '只能使用大小写字母、数字、下划线、小数点'),
+      type() === 'register' && match(/^[a-zA-Z]/, '使用大小写字母开头'),
+      type() === 'register' && length(6, 18, '长度应在6-18之内'),
+    ];
+  }
+
+  function passwdValidator(): Validator[] {
+    return [
+      required(),
+      type() === 'register' && length(6, 18, '长度应在6-18之内'),
+    ];
+  }
+
   return (
     <>
       <div
@@ -98,8 +118,19 @@ export default function AuthButton() {
               { label: '注册', value: 'register' },
             ]}
           />
-          <Input class="w-full" label="账户" field="account" />
-          <Input class="w-full" label="密码" type="password" field="passwd" />
+          <Input
+            class="w-full my-2"
+            label="账户"
+            field="account"
+            validate={accountValidator()}
+          />
+          <Input
+            class="w-full my-2"
+            label="密码"
+            type="password"
+            field="passwd"
+            validate={passwdValidator()}
+          />
           <div>
             <div>
               <input id="remember" type="checkbox" name="remember" />
@@ -107,9 +138,10 @@ export default function AuthButton() {
             </div>
           </div>
           <div class="py-5 flex justify-end">
-            <button class="text-white text-2xl px-2 py-1 cursor-pointer border-0 rounded-md bg-slate-600 hover:bg-slate-700">
-              {type() === 'register' ? '注册' : '登录'}
-            </button>
+            <Button
+              content={type() === 'register' ? '注册' : '登录'}
+              class="text-white text-2xl bg-slate-600 hover:bg-slate-700"
+            />
           </div>
         </form>
       </Modal>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  content?: string;
+  onClick?: () => void;
+  class?: string;
+  disabled?: boolean;
+}
+
+export default function Button(props: Props) {
+  function handleClick() {
+    props.onClick && props.onClick();
+  }
+
+  return (
+    <button
+      class={`relative border-0 rounded-md px-3 py-1 box-border cursor-pointer
+      ${props.class} 
+      ${
+        props.disabled &&
+        'after:content-empty after:w-full after:h-full after:absolute after:left-0 after:top-0 after:bg-white after:opacity-50'
+      }`}
+      onClick={handleClick}
+      disabled={props.disabled}
+    >
+      {props.content || 'button'}
+    </button>
+  );
+}

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -2,7 +2,7 @@ import { children, createSignal, For, JSX } from 'solid-js';
 import { debounce, isNumber, isString, isUndefined } from 'lodash';
 
 export interface DropdownOption {
-  key: string | number;
+  value: string | number;
   label: JSX.Element | string | number;
 }
 
@@ -53,7 +53,7 @@ export default function Dropdown(props: Props) {
       {visible() && (
         <div class="cursor-default absolute right-0 top-[110%] bg-slate-100 rounded-lg px-2 py-2">
           <For each={props.options}>
-            {({ key, label }) => (
+            {({ value, label }) => (
               <>
                 {(isNumber(label) || isString(label)) && (
                   <div
@@ -62,7 +62,7 @@ export default function Dropdown(props: Props) {
                       ((isNumber(label) || isString(label)) &&
                         ' hover:bg-slate-200 text-black')
                     }
-                    onClick={() => handleOptionClick(key)}
+                    onClick={() => handleOptionClick(value)}
                   >
                     {label}
                   </div>
@@ -70,7 +70,7 @@ export default function Dropdown(props: Props) {
                 {!isNumber(label) && !isString(label) && (
                   <div
                     class="cursor-pointer"
-                    onClick={() => handleOptionClick(key)}
+                    onClick={() => handleOptionClick(value)}
                   >
                     {label}
                   </div>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,22 +1,67 @@
+import { createSignal } from 'solid-js';
+import { Validator } from '@/types';
+import { debounce } from 'lodash';
+
 interface Props {
   field: string;
   type?: string;
   label?: string;
   class?: string;
+  validate?: Validator[];
+  defaultValue?: string;
 }
 
 export default function Input(props: Props) {
+  const [error, setError] = createSignal('');
+  const [value, setValue] = createSignal(props.defaultValue || '');
+
+  function handleInput(s: string) {
+    setError('');
+    setValue(s);
+    check(s);
+  }
+
+  const check = debounce(async (s: string) => {
+    if (props.validate) {
+      for (const validator of props.validate) {
+        if (!validator) continue;
+
+        const result = await validator(s);
+
+        if (result) {
+          setError(result);
+          break;
+        }
+      }
+    }
+  }, 500);
+
   return (
-    <div class={'mb-3 ' + props.class}>
-      <label for={props.field} class="block m-0">
+    <div
+      class={`border-2 ${
+        error() ? 'border-[#ee1111] text-[#ee1111]' : 'border-gray-400'
+      } border-solid box-border flex items-center px-2 py-1 bg-white rounded-md ${
+        props.class
+      }`}
+    >
+      <label for={props.field} class="box-border px-2 m-0">
         {props.label || props.field}
       </label>
-      <input
-        id={props.field}
-        class="block w-full box-border rounded-md px-2 outline-0 border-[1px] h-[30px]"
-        name={props.field}
-        type={props.type || 'text'}
-      />
+      <div class="flex-1 relative h-fit">
+        <input
+          id={props.field}
+          class="text-black block w-full box-border border-0 outline-0 bg-none px-2 py-2 h-[30px]"
+          name={props.field}
+          type={props.type || 'text'}
+          value={value()}
+          onInput={(e: any) => handleInput(e.target.value)}
+        />
+        {error() && (
+          <span class="text-[#ee1111] absolute -bottom-2 left-1 text-[12px] origin-top-left scale-75">
+            {error()}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -27,7 +27,7 @@ export default function Modal(props: Props & ParentProps<any>) {
             <header class="text-white bg-slate-700 px-2 py-0 border-b-2 border-black">
               <h2 class="m-0 py-1 px-2">{props.title}</h2>
             </header>
-            <main class="w-full">{props.children}</main>
+            <main class="w-full max-h-[80vh]">{props.children}</main>
           </div>
         </div>
       )}

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -18,29 +18,31 @@ export default function RadioGroup(props: Props) {
   };
 
   return (
-    <div class={`${props.class} box-border bg-gray-300 p-1 w-fit`}>
-      <For each={props.options}>
-        {({ label, value }) => (
-          <>
-            <label
-              class={`inline-block box-border px-2 py-1 cursor-pointer ${
-                currentValue() === value && 'bg-gray-200'
-              }`}
-              for={value}
-            >
-              {label}
-            </label>
-            <input
-              id={value}
-              type="radio"
-              class="hidden"
-              value={value}
-              name={props.field}
-              onChange={handleChange}
-            />
-          </>
-        )}
-      </For>
+    <div class={`${props.class} box-border rounded-md bg-gray-300 p-1`}>
+      <div class="w-full flex">
+        <For each={props.options}>
+          {({ label, value }) => (
+            <>
+              <label
+                class={`rounded-md inline-block box-border text-center px-2 py-1 whitespace-nowrap overflow-ellipsis cursor-pointer flex-1 ${
+                  currentValue() === value && 'bg-gray-200'
+                }`}
+                for={value}
+              >
+                {label}
+              </label>
+              <input
+                id={value}
+                type="radio"
+                class="hidden"
+                value={value}
+                name={props.field}
+                onChange={handleChange}
+              />
+            </>
+          )}
+        </For>
+      </div>
     </div>
   );
 }

--- a/src/components/UserInfoButton.tsx
+++ b/src/components/UserInfoButton.tsx
@@ -3,10 +3,10 @@ import { setJwt, setUser, user } from '@/store/user';
 
 export default function UserInfoButton() {
   const options: DropdownOption[] = [
-    { key: 'space', label: '个人空间' },
-    { key: 'settings', label: '修改信息' },
+    { value: 'space', label: '个人空间' },
+    { value: 'settings', label: '修改信息' },
     {
-      key: 'logout',
+      value: 'logout',
       label: (
         <div class="text-black hover:bg-red-700 hover:text-white m-0 px-2 py-2 rounded-md">
           注销账号

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,10 @@
-/* @refresh reload */
 import { render } from 'solid-js/web';
 
 import './index.css';
 import 'uno.css';
+import 'virtual:uno.css';
 import App from './App';
 import { Router } from '@solidjs/router';
-import 'virtual:uno.css';
 
 const root = document.getElementById('root');
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
-export interface ResponseError {
-  statusCode: number;
-  message: Record<string, any>;
-  error: string;
-}
+type MaybePromise<T> = T | Promise<T>;
+
+export type Validator =
+  | ((_: string) => MaybePromise<string>)
+  | false
+  | undefined;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,22 @@
+import { Validator } from '@/types';
+
+export function required(): Validator {
+  return (s: string) => (s ? '' : '必填项');
+}
+
+export function match(reg: RegExp, message?: string): Validator {
+  return (s: string) => (reg.test(s) ? '' : message || '格式不合法');
+}
+
+export function length(min: number, max: number, message?: string) {
+  return (s: string) => {
+    const n = s.length;
+    if (n < min) {
+      return message || `长度小于${min}`;
+    }
+    if (n > max) {
+      return message || `长度大于${max}`;
+    }
+    return '';
+  };
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,3 +1,5 @@
 import { defineConfig } from 'unocss';
 
-export default defineConfig({});
+export default defineConfig({
+  mergeSelectors: false,
+});


### PR DESCRIPTION
# Change Log

## 基建

- 删除`tailwind`，使用 `unocss`。
- 通用组件整理
  - Button
  - Dropdown
  - Input
  - Modal
  - RadioGroup

## 业务

- 用户注册登录输入框加上验证器
- 对其他部分的组件进行样式微调